### PR TITLE
Update cloudwatch-logs-and-interface-VPC.md

### DIFF
--- a/doc_source/cloudwatch-logs-and-interface-VPC.md
+++ b/doc_source/cloudwatch-logs-and-interface-VPC.md
@@ -8,7 +8,7 @@ To get started, create an interface VPC endpoint\. You do not need to change the
 
 CloudWatch Logs currently supports VPC endpoints in the following Regions:
 
-+ United States \(Oregon\);
++ US West \(Oregon\);
 
 + Asia Pacific \(Tokyo\);
 

--- a/doc_source/cloudwatch-logs-and-interface-VPC.md
+++ b/doc_source/cloudwatch-logs-and-interface-VPC.md
@@ -8,6 +8,8 @@ To get started, create an interface VPC endpoint\. You do not need to change the
 
 CloudWatch Logs currently supports VPC endpoints in the following Regions:
 
++ United States \(Oregon\);
+
 + Asia Pacific \(Tokyo\);
 
 + South America \(São Paulo\)


### PR DESCRIPTION
Added us-west-2 to the supported VPC endpoints for CloudWatch Logs Private Link

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
