### PR TITLE
Update AgentReference.md

### DIFF
--- a/doc_source/AgentReference.md
+++ b/doc_source/AgentReference.md
@@ -14,6 +14,8 @@ The CloudWatch Logs agent configuration file describes information needed by the
 state_file = value
 logging_config_file = value
 use_gzip_http_content_encoding = [true | false]
+aws_access_key_id = value
+aws_secret_access_key = value
 
 [logstream1]
 log_group_name = value


### PR DESCRIPTION
The below options [1] are supported, however are commonly added when configuring awslogs interactively.

If configuring the awslogs.conf file programatically, or supplying it during deployment these options are convenient to know

[1]
aws_access_key_id = value
aws_secret_access_key = value


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
