### PR TITLE
Example output for FirehosetoS3Role trust relationship should be fire…

### DIFF
--- a/doc_source/SubscriptionFilters.md
+++ b/doc_source/SubscriptionFilters.md
@@ -379,7 +379,7 @@ Before you create the Kinesis Firehose stream, calculate the volume of log data 
                    "Action": "sts:AssumeRole",
                    "Effect": "Allow",
                    "Principal": {
-                       "Service": "logs.region.amazonaws.com"
+                       "Service": "firehose.amazonaws.com"
                    }
                }
            },


### PR DESCRIPTION
*Issue #, if available: n/a*

*Description of changes: example output for creating FirehosetoS3Role shows logs.region - should be firehose *


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
