### PR TITLE
Use standalone install

### DIFF
--- a/doc_source/EC2NewInstanceCWL.md
+++ b/doc_source/EC2NewInstanceCWL.md
@@ -116,7 +116,9 @@ datetime_format = %b %d %H:%M:%S
    #!/bin/bash
    curl https://s3.amazonaws.com//aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
    chmod +x ./awslogs-agent-setup.py
-   ./awslogs-agent-setup.py -n -r us-east-1 -c s3://myawsbucket/my-config-file
+   curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/AgentDependencies.tar.gz -O
+   tar xvf AgentDependencies.tar.gz -C /tmp/
+   ./awslogs-agent-setup.py -n -r us-east-1 --dependency-path /tmp/AgentDependencies -c s3://myawsbucket/my-config-file
    ```
 
 1. Make any other changes to the instance, review your launch settings, and then choose **Launch**\.


### PR DESCRIPTION
*Issue #, if available:*

aws/aws-cli#4278

*Description of changes:*

Use standalone install instead of pip install.  It is because:

* `awslogs-agent-setup.py` uses pip 6.1.1 which is very old and dangerous.
* Online install may fail when PyPI is down.
* Online install is polluting PyPI download stats, and consumes resource Fastly provides.