### PR TITLE
Update Policy suggestion with condition

### DIFF
--- a/doc_source/encrypt-log-data-kms.md
+++ b/doc_source/encrypt-log-data-kms.md
@@ -72,7 +72,11 @@ Open the `policy.json` file in a text editor and add the statement in bold, repl
         "kms:GenerateDataKey*",
         "kms:Describe*"
       ],
-      "Resource": "*"
+      "Resource": "*",
+      "StringLike": {
+          "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:region:Your_account_ID:log-group:*"
+        }
+      }
     }  
   ]
 }


### PR DESCRIPTION
The Policy provided allows a KMS key to be called by any AWS Account for the purpose of Cloudwatch Logs. 

*Description of changes:*
The condition prevents this and ensures the Key can only be used from a specific account.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
