### PR TITLE
Update S3ExportTasks.md

### DIFF
--- a/doc_source/S3ExportTasks.md
+++ b/doc_source/S3ExportTasks.md
@@ -140,7 +140,10 @@ By default, all Amazon S3 buckets and objects are private\. Only the resource ow
                "Principal": { "Service": "logs.us-west-2.amazonaws.com" }
            },
            {
-               "Action": "s3:PutObject" ,
+               "Action": [
+                "s3:PutObject",
+                "s3:PutObjectAcl"
+               ],
                "Effect": "Allow",
                "Resource": "arn:aws:s3:::my-exported-logs/random-string/*",
                "Condition": { "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" } },


### PR DESCRIPTION
lambda in one account can not start export cloudwatch logs to the S3 bucket in another account, if lambda execution role doesn't have permission "s3:PutObjectAcl"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
