### PR TITLE
Update Example 4: Multiple terms section

### DIFF
--- a/doc_source/FilterAndPatternSyntax.md
+++ b/doc_source/FilterAndPatternSyntax.md
@@ -26,7 +26,7 @@ The filter pattern "ERROR" matches log event messages that contain this term, su
 In the previous example, if you change the filter pattern to "ERROR" \- "Exiting", the log event message "Exiting with ERRORCODE: \-1" would be excluded\.
 
 **Example 4: Multiple terms**  
-The filter pattern "ERROR Exception" matches log event messages that contain both terms, such as the following:
+The filter pattern "ERROR" "Exception" matches log event messages that contain both terms, such as the following:
 + \[ERROR\] Caught IllegalArgumentException
 + \[ERROR\] Unhandled Exception
 


### PR DESCRIPTION
While trying to create a filter pattern to find two nonconsecutive terms in CloudWatch logs and not being able to do following the Example 4 filter, we found out that the correct syntax for N number of nonconsecutive terms would be: "Term1" "Term2" "TermN" (each term with their own quotes).
Thus, "ERROR Exception" should be updated to "ERROR" "Exception"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
