### PR TITLE
Clarified that default value has no effect if logs are not ingested

### DIFF
--- a/doc_source/MonitoringLogData.md
+++ b/doc_source/MonitoringLogData.md
@@ -31,4 +31,4 @@ The destination namespace of the new CloudWatch metric\.
 The numerical value to publish to the metric each time a matching log is found\. For example, if you're counting the occurrences of a particular term like "Error", the value will be "1" for each occurrence\. If you're counting the bytes transferred, you can increment by the actual number of bytes found in the log event\.
 
 **default value**  
-The value reported to the metric filter during a period when no matching logs are found\. By setting this to 0, you ensure that data is reported during every period, preventing "spotty" metrics with periods of no data\.
+The value reported to the metric filter during a period when logs are ingested but no matching logs are found\. By setting this to 0, you ensure that data is reported during every such period, preventing "spotty" metrics with periods of no matching data\. Note that if no log events are ingested during a one-minute period, then no value is reported\.  


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Added a minor but important detail about "default value". Not having it mentioned here caused us to raise a support case ID 7488227761.
Later I found this information mentioned in https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html section "Setting How the Metric Value Changes When Matches Are Found", but for the sake of completeness, I think it is worth having it here as well.

--

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
