### PR TITLE
Update StartTheCWLAgent.md

### DIFF
--- a/doc_source/StartTheCWLAgent.md
+++ b/doc_source/StartTheCWLAgent.md
@@ -19,3 +19,7 @@ If the CloudWatch Logs agent on your EC2 instance did not start automatically af
    ```
    sudo service awslogsd start
    ```
+   Alternatively, you can manually start the application with the following command:
+   ```
+   sudo /opt/aws/amazon-cloudwatch-agent/bin/start-amazon-cloudwatch-agent
+   ```


### PR DESCRIPTION
*Issue #, if available:*

The documentation seems to be out of date.
On Amazon Linux 2, the `awslogsd` service dosent seem to exist.

![image](https://user-images.githubusercontent.com/25075013/140712392-3ad563c1-b4f9-402b-867c-2dd00f0a82e2.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
