### PR TITLE
Change 'data' grammar

### DIFF
--- a/doc_source/CWL_AnalyzeLogData_RunSampleQuery.md
+++ b/doc_source/CWL_AnalyzeLogData_RunSampleQuery.md
@@ -47,7 +47,7 @@ Some sample queries provided with CloudWatch Logs Insights use `head` or `tail` 
 
 1. In the query editor, change **20** to **50**, and then choose **Run**\.
 
-   The results of the new query appear\. Assuming there is enough data in the log group in the default time range, there are now 50 log events listed\.
+   The results of the new query appear\. Assuming there are enough data in the log group in the default time range, there are now 50 log events listed\.
 
 1. \(Optional\) You can save queries that you have created\. To save this query, choose **Save**\. For more information, see [Saving and re\-running CloudWatch Logs Insights queries](CWL_Insights-Saving-Queries.md)\.
 


### PR DESCRIPTION
Change 'data' to plural noun. 'there is enough data' -> 'there are enough data'

*Issue #, if available:*

*Description of changes:*
Single word change to [line 50](https://github.com/awsdocs/amazon-cloudwatch-logs-user-guide/blob/5bd7d2470d67c936128b739e8a4aaa85c3eb8b7b/doc_source/CWL_AnalyzeLogData_RunSampleQuery.md?plain=1#L50) verbiage


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
