### PR TITLE
Added a policy example for when the kinesis stream uses encryption

### DIFF
--- a/doc_source/CreateDestination.md
+++ b/doc_source/CreateDestination.md
@@ -117,6 +117,20 @@ When the destination is created, CloudWatch Logs sends a test message to the des
    }
    ```
 
+1. If the recepient Kinesis Stream uses server-side encryption with KMS, the role also needs kms:GenerateDataKey permissions: 
+
+```
+   {
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": "kms:GenerateDataKey",
+         "Resource": "arn:aws:kms:region:999999999999:key/*"
+       }
+     ]
+   }
+```
+
 1. Associate the permissions policy with the role by using the **aws iam put\-role\-policy** command:
 
    ```


### PR DESCRIPTION
Reference: https://docs.aws.amazon.com/streams/latest/dev/permissions-user-key-KMS.html

Failing to add the `kms:GenerateDataKey` permission to the IAM role causes the following error: 
```
Could not deliver test message to specified destination. Check if the destination is valid.
```