### PR TITLE
PermissionsForFirehose should be my-bucket/*

### DIFF
--- a/doc_source/SubscriptionFilters.md
+++ b/doc_source/SubscriptionFilters.md
@@ -414,7 +414,7 @@ Before you create the Kinesis Data Firehose stream, calculate the volume of log 
              "s3:PutObject" ],
          "Resource": [ 
              "arn:aws:s3:::my-bucket", 
-             "arn:aws:s3:::my-bucket/" ]
+             "arn:aws:s3:::my-bucket/*" ]
        }
      ]
    }


### PR DESCRIPTION
The example given for PermissionsForFirehose.js states that the Resource should include my-bucket and my-bucket/ when what is really needed is, my-bucket and my-bucket/*

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
