### PR TITLE
`%f` also supports milliseconds

### DIFF
--- a/doc_source/AgentReference.md
+++ b/doc_source/AgentReference.md
@@ -119,7 +119,7 @@ The common datetime\_format codes are listed below\. You can also use any dateti
 **%p**: Locale's equivalent of either AM or PM\.  
 **%M**: Minute as a zero\-padded decimal number\. 00, 01, \.\.\., 59  
 **%S**: Second as a zero\-padded decimal number\. 00, 01, \.\.\., 59  
-**%f**: Microsecond as a decimal number, zero\-padded on the left\. 000000, \.\.\., 999999  
+**%f**: Second fraction as a decimal number, zero\-padded on the left\. 000000, \.\.\., 999999 for microseconds; 000, \.\.\., 999 for milliseconds etc.
 **%z**: UTC offset in the form \+HHMM or \-HHMM\. \+0000, \-0400, \+1030  
 **Example formats:**  
 `Syslog: '%b %d %H:%M:%S', e.g. Jan 23 20:59:29`  


### PR DESCRIPTION
*Description of changes:*
As mentioned in note (4) on https://docs.python.org/2/library/datetime.html, `%f` not only supports microseconds but “from one to six digits”. Some software uses millisecond precision, so I think milliseconds are worth mentioning explicitly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
